### PR TITLE
fix _proj_point_to_tile_point for transform_coord in geom

### DIFF
--- a/src/lcmap/client/geom.py
+++ b/src/lcmap/client/geom.py
@@ -15,14 +15,14 @@ def _tile_point_to_proj_point(tile_x, tile_y, transform):
 
 def _proj_point_to_tile_point(proj_x, proj_y, transform):
     "Translate map coordinates into image coordinates"
-    inv_transform = gdal.InvGeoTransform(transform)
+    inv_transform = gdal.InvGeoTransform(transform).pop()
     image_x = (inv_transform[0] +
                proj_x * inv_transform[1] +
                proj_y * inv_transform[2])
     image_y = (inv_transform[3] +
                proj_x * inv_transform[4] +
                proj_y * inv_transform[5])
-    return (int(floor(image_x)), int(floor(image_y)))
+    return int(floor(image_x)), int(floor(image_y))
 
 
 def transform_coord(coord, matrix, src="", dst=""):

--- a/src/lcmap/client/geom.py
+++ b/src/lcmap/client/geom.py
@@ -1,28 +1,27 @@
-from math import floor
-from osgeo import gdal
+from math import floor, ceil
+from collections import namedtuple
+
+GeoAffine = namedtuple('GeoAffine', ['ul_x', 'x_res', 'rot_1', 'ul_y', 'rot_2', 'y_res'])
 
 
 def _tile_point_to_proj_point(tile_x, tile_y, transform):
-    "Translate image coordinates into map coordinates"
-    map_x = (transform[0] +
-             tile_x * transform[1] +
-             tile_y * transform[2])
-    map_y = (transform[3] +
-             tile_x * transform[4] +
-             tile_y * transform[5])
-    return (map_x, map_y)
+    """
+    Translate image row, column into map coordinates
+    """
+    map_x = transform.ul_x + tile_x * transform.x_res + tile_y * transform.rot_1
+    map_y = transform.ul_y + tile_x * transform.rot_2 + tile_y * transform.y_res
+
+    return map_x, map_y
 
 
 def _proj_point_to_tile_point(proj_x, proj_y, transform):
-    "Translate map coordinates into image coordinates"
-    inv_transform = gdal.InvGeoTransform(transform).pop()
-    image_x = (inv_transform[0] +
-               proj_x * inv_transform[1] +
-               proj_y * inv_transform[2])
-    image_y = (inv_transform[3] +
-               proj_x * inv_transform[4] +
-               proj_y * inv_transform[5])
-    return int(floor(image_x)), int(floor(image_y))
+    """
+    Translate map coordinates into image coordinates
+    Assumes North is up
+    """
+    col = floor((proj_x - transform.ul_x - transform.ul_y * transform.rot_1) / transform.x_res)
+    row = ceil((proj_y - transform.ul_y - transform.ul_x * transform.rot_2) / transform.y_res)
+    return int(col), int(row)
 
 
 def transform_coord(coord, matrix, src="", dst=""):
@@ -43,9 +42,6 @@ def transform_coord(coord, matrix, src="", dst=""):
 
 
 def get_transform_matrix(tile, spec):
-    ""
-    upper_left_map_x, upper_left_map_y = tile.x, tile.y
-    pixel_res_meters_x, pixel_res_meters_y = spec['pixel_x'], spec['pixel_y']
-    rotation = 0.0
-    return [upper_left_map_x, pixel_res_meters_x, rotation,
-            upper_left_map_y, rotation, pixel_res_meters_y]
+    """Return Geo Transform matrix for given tile, spec"""
+    return GeoAffine(tile['x'], spec['pixel_x'], spec['shift_x'],
+                     tile['y'], spec['shift_y'], spec['pixel_y'])

--- a/src/lcmap/client/tile.py
+++ b/src/lcmap/client/tile.py
@@ -48,7 +48,7 @@ class Tile(object):
         self._tile = tile
         self._spec = spec
         self._data = decode(spec, tile, mask, shape, unscale)
-        self._point_transformer = geom.get_transform_matrix(self, spec)
+        self._point_transformer = geom.get_transform_matrix(tile, spec)
         pass
 
     @property
@@ -81,9 +81,5 @@ class Tile(object):
 
     def __getitem__(self, proj_point):
         """Get value for given projection point"""
-        # XXX why isn't this next line using the self._point_transformer matrix
-        #     that's areadly been created?
-        tm = geom.get_transform_matrix(self, self._spec)  # blech
-        (x, y) = proj_point
-        (tx, ty) = geom.transform_coord(proj_point, tm, src="map", dst="image")
+        (tx, ty) = geom.transform_coord(proj_point, self._point_transformer, src="map", dst="image")
         return self._data[tx, ty]

--- a/tests/test_lcmap_client.py
+++ b/tests/test_lcmap_client.py
@@ -1,48 +1,53 @@
 import unittest
 
-from lcmap.client import Client, geom
+from lcmap.client import Client
 
 
 class ClientTestCase(unittest.TestCase):
 
     def setUp(self):
         self.client = Client()
+        # corner of tile, api currently reporting
+        # floor, 'should' be ceil
+        self.tx, self.ty = -1850880, 2952960
+        # random geo coords
+        self.px, self.py = -1850865, 2956785
         self.params = {
             'band': 'LANDSAT_8/OLI_TIRS/sr_band2',
-            'x':    -1850865,
-            'y':     2956785,
+            'x': self.px,
+            'y': self.py,
             't1':   '2013-01-01',
             't2':   '2015-01-01'
         }
-        self.spec, self.tiles = self.client.data.surface_reflectance.tiles(**self.params)
+        self.spec, self.tiles = self.client.data.tiles(**self.params)
         self.tile = self.tiles[0]
 
     def test_init(self):
         self.assertIsNotNone(self.client)
 
     def test_tile_point(self):
-        self.assertEqual(self.tile.x, -1850865)
-        self.assertEqual(self.tile.y,  2956785)
+        self.assertEqual(self.tile.x, self.tx)
+        self.assertEqual(self.tile.y, self.ty)
 
     def test_tile_acquired(self):
-        self.assertEqual(self.tile.acquired, '2013-08-04T00:00:00Z')
+        self.assertEqual(self.tile.acquired, '2013-04-14T05:00:00Z')
 
     def test_tile_ubid(self):
         self.assertEqual(self.tile.ubid, 'LANDSAT_8/OLI_TIRS/sr_band2')
 
     def test_tile_shape(self):
-        self.assertEqual(self.tile.data.shape, (256,256))
+        self.assertEqual(self.tile.data.shape, (128, 128))
 
     def test_tile_data(self):
-        px,py = -1850865, 2956785
-        tx,ty = 0, 0
-        self.assertEqual(self.tile[px,py], self.tile.data[tx,ty])
-        px,py = -1850865+30, 2956785-30
-        tx,ty = 1, 1
-        self.assertEqual(self.tile[px,py], self.tile.data[tx,ty])
-        px,py = -1850865+(30*128), 2956785-(30*128)
-        tx,ty = 128, 128
-        self.assertEqual(self.tile[px,py], self.tile.data[tx,ty])
+        x, y = self.tx, self.ty
+        tx, ty = 0, 0
+        self.assertEqual(self.tile[x, y], self.tile.data[tx, ty])
+        x, y = self.tx+30, self.ty-30
+        tx, ty = 1, 1
+        self.assertEqual(self.tile[x, y], self.tile.data[tx, ty])
+        x, y = self.tx+(30*127), self.ty-(30*127)
+        tx, ty = 127, 127
+        self.assertEqual(self.tile[x, y], self.tile.data[tx, ty])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
gdal.InvGeoTransform returns a list, and its the 2nd item in this list which contains the values needed for the coordinate transformation